### PR TITLE
correct wording mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Also you will see a Makefile which you should use in order to build your protoco
 http://toolbox.pep-dortmund.org/install.html
 
 ## Die halbe Trommel zum Glück
-Physicians will be glad to see this :)
+Physicists will be glad to see this :)
 
 ## Editor Guide
 Find out how to optimize your atom text editor.


### PR DESCRIPTION
something that has been bugging me FOR YEARS. “physicians” are medical doctors and practitioners; “physicist” is the correct english term for describing people who work in the natural science of _physics_.

related to #3 